### PR TITLE
JBEAP-6439 - Enable / disable WS statistics does not reset counters

### DIFF
--- a/src/main/java/org/jboss/wsf/spi/management/EndpointMetrics.java
+++ b/src/main/java/org/jboss/wsf/spi/management/EndpointMetrics.java
@@ -50,4 +50,5 @@ public interface EndpointMetrics
    
    long getUpdateTime();
 
+   void resetMetrics();
 }


### PR DESCRIPTION
To fix JBEAP-6439, the metrics need to provide a reset() method.

Issue: https://issues.jboss.org/browse/JBEAP-6439
Upstream Issue: https://issues.jboss.org/browse/JBWS-4047

Please do not merge before reviewing commont on JBEAP-6439. This is merely a proposal fix, and I honestly need it needs to feedback and approval before merging. Also not it is tied to two others PRs:
- JBoss Common: https://github.com/jbossws/jbossws-common/pull/5
- JBossCXF; https://github.com/jbossws/jbossws-cxf/pull/19



